### PR TITLE
Cleanup ObjectId comparison code; remove leftover logs

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,23 +165,6 @@ app.get('/members', passport.authenticate('bearer', { session: false }),
   }
 );
 
-// This endpoint is moot until Family layer is introduced
-// Until then, the Google Auth routes are effectively adding users
-app.post('/members', passport.authenticate('bearer', { session: false }),
-  ({ body }, res) => {
-    log(`POST /members, body: ${body}`);
-
-    Members.create(body)
-
-    .then(res.json)
-
-    .catch((err) => {
-      console.error(err);
-      res.sendStatus(404);
-    });
-  }
-);
-
 // ===== COMMENTS =====
 
 app.post('/comments', passport.authenticate('bearer', { session: false }),

--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ app.get('/messages',
         messages: messages.map(message =>
           Object.assign(message, {
             comments: message.comments.filter(comment =>
-              comment.from.toString() === user._id.toString() || comment.to.toString() === user._id.toString()
+              user._id.equals(comment.from) || user._id.equals(comment.to)
             )
           })
         )
@@ -188,9 +188,6 @@ app.post('/comments', passport.authenticate('bearer', { session: false }),
   ({ body, user }, res) => {
     log(`POST /comments/:${body.messageId}`);
 
-    log('user', user);
-    log('body:', body);
-
     Messages.update(
       { _id: body.messageId },
       { $push: { comments: {
@@ -201,7 +198,6 @@ app.post('/comments', passport.authenticate('bearer', { session: false }),
     )
 
     .then((data) => {
-      log(data);
       if (data.nModified > 0) {
         res.sendStatus(200);
       } else {
@@ -226,7 +222,6 @@ app.delete('/comments/:userId/:messageId/:commentId',
     )
 
     .then((status) => {
-      log(status);
       if (status.nModified > 0) {
         res.sendStatus(202);
       } else {


### PR DESCRIPTION
Documentation re: the builtin method of comparing Mongo ObjectIds without coercing to string: 

http://mongodb.github.io/node-mongodb-native/api-bson-generated/objectid.html#equals