### PR TITLE
Cleanup ObjectId comparison code; remove leftover logs (#25)

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ app.get('/messages',
         messages: messages.map(message =>
           Object.assign(message, {
             comments: message.comments.filter(comment =>
-              comment.from.toString() === user._id.toString() || comment.to.toString() === user._id.toString()
+              user._id.equals(comment.from) || user._id.equals(comment.to)
             )
           })
         )
@@ -165,31 +165,11 @@ app.get('/members', passport.authenticate('bearer', { session: false }),
   }
 );
 
-// This endpoint is moot until Family layer is introduced
-// Until then, the Google Auth routes are effectively adding users
-app.post('/members', passport.authenticate('bearer', { session: false }),
-  ({ body }, res) => {
-    log(`POST /members, body: ${body}`);
-
-    Members.create(body)
-
-    .then(res.json)
-
-    .catch((err) => {
-      console.error(err);
-      res.sendStatus(404);
-    });
-  }
-);
-
 // ===== COMMENTS =====
 
 app.post('/comments', passport.authenticate('bearer', { session: false }),
   ({ body, user }, res) => {
     log(`POST /comments/:${body.messageId}`);
-
-    log('user', user);
-    log('body:', body);
 
     Messages.update(
       { _id: body.messageId },
@@ -201,7 +181,6 @@ app.post('/comments', passport.authenticate('bearer', { session: false }),
     )
 
     .then((data) => {
-      log(data);
       if (data.nModified > 0) {
         res.sendStatus(200);
       } else {
@@ -226,7 +205,6 @@ app.delete('/comments/:userId/:messageId/:commentId',
     )
 
     .then((status) => {
-      log(status);
       if (status.nModified > 0) {
         res.sendStatus(202);
       } else {


### PR DESCRIPTION
* cleanup ObjectId comparison code; remove leftover logs

* Remove leftover POST to members since authentication (login in frontend) is the only way to get the required information for creating a user.  I.e., manual user creation is impossible since you won't know their google ID

* Delete unused `Members` model